### PR TITLE
Add support for keyword list using square brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 [![Hex.pm](https://img.shields.io/hexpm/v/destructure.svg)](https://hex.pm/packages/destructure)
 [![Build Status](https://travis-ci.org/danielberkompas/destructure.svg?branch=master)](https://travis-ci.org/danielberkompas/destructure)
 
-Adds Javascript-style destructuring to Elixir. Instead of:
+Adds Javascript-style destructuring to Elixir. When working with `map`, instead
+of writing match operation like this:
 
 ```elixir
 def full_name(%{first_name: first_name, last_name: last_name}) do
@@ -20,16 +21,20 @@ def full_name(d%{first_name, last_name}) do
 end
 ```
 
-Or with structs:
+It also works with `structs` and `keyword`.
+
 ```elixir
 import Destructure
 
 def full_name(d%Person{first_name, last_name}) do
   "#{first_name} #{last_name}"
 end
+def full_name(d[first_name, last_name]) do
+  "#{first_name} #{last_name}"
+end
 ```
 
-It also works in case statements, like this:
+You can also do it in case statement.
 
 ```elixir
 case post(url, data) do
@@ -50,18 +55,10 @@ See the [Hex Documentation](https://hexdocs.pm/destructure) for more details.
 
 ## Installation
 
-  1. Add `destructure` to your list of dependencies in `mix.exs`:
+Add `destructure` to your list of dependencies in `mix.exs`:
 
-    ```elixir
-    def deps do
-      [{:destructure, "~> 0.2.2"}]
-    end
-    ```
-
-  2. Ensure `destructure` is started before your application:
-
-    ```elixir
-    def application do
-      [applications: [:destructure]]
-    end
-    ```
+```elixir
+def deps do
+  [{:destructure, "~> 0.2.2"}]
+end
+```

--- a/lib/destructure.ex
+++ b/lib/destructure.ex
@@ -5,7 +5,7 @@ defmodule Destructure do
   """
 
   @doc """
-  Easy destructuring of maps, structs, and keyword lists, with atom keys only.
+  Easy destructuring of `map`, `structs`, and `keyword`, with atom keys only.
   String keys are not supported because Elixir raises a `SyntaxError` on syntax
   like `%{"name"}`. Optional key also need to be placed at the last for the same
   reason with the string key.
@@ -63,21 +63,21 @@ defmodule Destructure do
 
   For keyword lists:
 
-      iex> d({name}) = [name: "Daniel"]
+      iex> d([name]) = [name: "Daniel"]
       ...> name
       "Daniel"
 
   With multiple keys:
 
-      iex> d({first, last}) = [first: "Daniel", last: "Berkompas"]
-      ...> {first, last}
-      {"Daniel", "Berkompas"}
+      iex> d([first, last]) = [first: "Daniel", last: "Berkompas"]
+      ...> [first, last]
+      ["Daniel", "Berkompas"]
 
   With multiple keys and custom assignment:
 
-      iex> d({first, last, email: mail}) = [first: "Daniel", last: "Berkompas", email: "top@secret.com"]
-      ...> {first, last, mail}
-      {"Daniel", "Berkompas", "top@secret.com"}
+      iex> d([first, last, email: mail]) = [first: "Daniel", last: "Berkompas", email: "top@secret.com"]
+      ...> [first, last, mail]
+      ["Daniel", "Berkompas", "top@secret.com"]
 
   And in function definitions:
 
@@ -114,6 +114,11 @@ defmodule Destructure do
   # {{:first, [], Elixir}, {:last, [], Elixir}}
   defmacro d({first, second}) do
     [pattern(first), pattern(second)]
+  end
+
+  # Handle keyword list using square bracket
+  defmacro d(list) when is_list(list) do
+    Enum.map(list, &pattern/1)
   end
 
   defp pattern({key, _, _} = variable) do

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"earmark": {:hex, :earmark, "1.0.2", "a0b0904d74ecc14da8bd2e6e0248e1a409a2bc91aade75fcf428125603de3853", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+%{"earmark": {:hex, :earmark, "1.0.2", "a0b0904d74ecc14da8bd2e6e0248e1a409a2bc91aade75fcf428125603de3853", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"}}


### PR DESCRIPTION
Previously, we can only use curly brackets for keyword list.
```elixir
d({foo}) = [foo: "bar"]
```
Now, we can also use square brackets for convenient use.
```elixir
d([foo]) = [foo: "bar"]
```