### PR TITLE
Handle stringly keyed maps!

### DIFF
--- a/lib/destructure.ex
+++ b/lib/destructure.ex
@@ -43,19 +43,19 @@ defmodule Destructure do
 
   For Maps with String Keys:
 
-      iex> d(s%{name}) = %{"name" => "Daniel Berkompas"}
+      iex> s(%{name}) = %{"name" => "Daniel Berkompas"}
       ...> name
       "Daniel Berkompas"
 
   With multiple keys:
 
-      iex> d(s%{name, email}) = %{"name" => "Daniel Berkompas", "email" => "top@secret.com"}
+      iex> s(%{name, email}) = %{"name" => "Daniel Berkompas", "email" => "top@secret.com"}
       ...> {name, email}
       {"Daniel Berkompas", "top@secret.com"}
 
   With multiple keys and custom variable naming:
 
-      iex> d(s%{name, "email" => mail}) = %{"name" => "Daniel Berkompas", "email" => "top@secret.com"}
+      iex> s(%{name, "email" => mail}) = %{"name" => "Daniel Berkompas", "email" => "top@secret.com"}
       ...> {name, mail}
       {"Daniel Berkompas", "top@secret.com"}
 
@@ -113,12 +113,6 @@ defmodule Destructure do
     {:%{}, context, Enum.map(args, &pattern/1)}
   end
 
-  # Handle string maps, including ones with multiple keys
-  # {:s, [], [{:%{}, [], [{:stuff, [], Elixir}, {:things, [], Elixir}]}]}
-  defmacro d({:s, _, [{:%{}, context, args}]}) do
-    {:%{}, context, Enum.map(args, &s_pattern/1)}
-  end
-
   # Handle structs, including ones with multiple keys
   # {:%, [],
   #  [{:__aliases__, [alias: false], [:Namespace]},
@@ -142,6 +136,12 @@ defmodule Destructure do
   # Handle keyword list using square bracket
   defmacro d(list) when is_list(list) do
     Enum.map(list, &pattern/1)
+  end
+
+  # Handle string maps, including ones with multiple keys
+  # {:%{}, [], [{:stuff, [], Elixir}, {:things, [], Elixir}]}
+  defmacro s({:%{}, context, args}) do
+    {:%{}, context, Enum.map(args, &s_pattern/1)}
   end
 
   defp s_pattern({key, _, _} = variable) do

--- a/lib/destructure.ex
+++ b/lib/destructure.ex
@@ -5,10 +5,8 @@ defmodule Destructure do
   """
 
   @doc """
-  Easy destructuring of `map`, `structs`, and `keyword`, with atom keys only.
-  String keys are not supported because Elixir raises a `SyntaxError` on syntax
-  like `%{"name"}`. Optional key also need to be placed at the last for the same
-  reason with the string key.
+  Easy destructuring of `map`, `structs`, `keyword`, with atom keys.
+  String keys are supported via a special syntax `d(s%{param})`.
 
   ## Examples
 
@@ -42,6 +40,25 @@ defmodule Destructure do
       iex> d(%{first, last, email: mail}) = %{first: "Daniel", last: "Berkompas", email: "top@secret.com"}
       ...> {first, last, mail}
       {"Daniel", "Berkompas", "top@secret.com"}
+
+  For Maps with String Keys:
+
+      iex> d(s%{name}) = %{"name" => "Daniel Berkompas"}
+      ...> name
+      "Daniel Berkompas"
+
+  With multiple keys:
+
+      iex> d(s%{name, email}) = %{"name" => "Daniel Berkompas", "email" => "top@secret.com"}
+      ...> {name, email}
+      {"Daniel Berkompas", "top@secret.com"}
+
+  With multiple keys and custom variable naming:
+
+      iex> d(s%{name, "email" => mail}) = %{"name" => "Daniel Berkompas", "email" => "top@secret.com"}
+      ...> {name, mail}
+      {"Daniel Berkompas", "top@secret.com"}
+
 
   For structs:
 
@@ -96,6 +113,12 @@ defmodule Destructure do
     {:%{}, context, Enum.map(args, &pattern/1)}
   end
 
+  # Handle string maps, including ones with multiple keys
+  # {:s, [], [{:%{}, [], [{:stuff, [], Elixir}, {:things, [], Elixir}]}]}
+  defmacro d({:s, _, [{:%{}, context, args}]}) do
+    {:%{}, context, Enum.map(args, &s_pattern/1)}
+  end
+
   # Handle structs, including ones with multiple keys
   # {:%, [],
   #  [{:__aliases__, [alias: false], [:Namespace]},
@@ -121,12 +144,20 @@ defmodule Destructure do
     Enum.map(list, &pattern/1)
   end
 
+  defp s_pattern({key, _, _} = variable) do
+    {key |> Atom.to_string(), variable}
+  end
+
+  defp s_pattern(otherwise), do: pattern(otherwise)
+
   defp pattern({key, _, _} = variable) do
     {key, variable}
   end
+
   defp pattern([arg]) do
     arg
   end
+
   defp pattern(other) do
     other
   end


### PR DESCRIPTION
This enables syntax in Phoenix controllers per the following.
```elixir
import Destructure
def index(conn, s(%{id})), do: MyEctoModel |> Repo.get(id)
```